### PR TITLE
Updated mesh_maze.py to be Blender 2.9+ compatible

### DIFF
--- a/mesh_maze.py
+++ b/mesh_maze.py
@@ -178,7 +178,7 @@ def bevel_extrude(bm, sel_geom, maze_params, link_centers, vert_centers):
             offset=maze_params['offset'],
             offset_type=maze_params['offset_type'],
             segments=1,
-            profile=0.5, vertex_only=0,
+            profile=0.5, affect='EDGES',
             loop_slide=maze_params['use_loop_slide'],
             clamp_overlap=maze_params['use_clamp_overlap'],
             material=-1)


### PR DESCRIPTION
Since the bevel param "vertex_only" was removed and replaced with "affect" in Blender 2.9, it made line 181 in mesh_maze.py incompatible with 2.9. I have changed the line `profile=0.5, vertex_only=0,` to `profile=,0.5, affect='EDGES'`. This fixes the issue and makes the addon usable again. I don't know if "EDGES" has to be capitalized but it was in the Blender Python API. I have very little coding experience and just figured this out through mostly trial and error. It was a simple fix.